### PR TITLE
remove `any` type error

### DIFF
--- a/pring.ts
+++ b/pring.ts
@@ -580,7 +580,7 @@ export module Pring {
             }
         }
 
-        async get(type: { new(id): T; }) {
+        async get(type: { new(id: string): T; }) {
             this.parent._init()
             try {
                 const snapshot: FirebaseFirestore.QuerySnapshot = await this.reference.get()

--- a/types/pring.d.ts
+++ b/types/pring.d.ts
@@ -106,7 +106,7 @@ export declare module Pring {
         delete(member: T): void;
         pack(type: BatchType, batch?: FirebaseFirestore.WriteBatch): FirebaseFirestore.WriteBatch;
         get(type: {
-            new (id): T;
+            new (id: string): T;
         }): Promise<T[]>;
     }
     class CountableReferenceCollection<T extends Base> implements AnySubCollection, ValueProtocol, Batchable {


### PR DESCRIPTION
fix `node_modules/pring/types/pring.d.ts(109,18): error TS7006: Parameter 'id' implicitly has an 'any' type.`